### PR TITLE
[Cursor] docs: improve markdown instructions and fix setup issues

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -37,8 +37,6 @@ cd openhands-expense-calculator
 pip install -r requirements.txt
 
 # Run the application
-python run_app.py
-# OR
 streamlit run run_app.py
 
 # Access at: http://localhost:8501

--- a/QUICK_START.md
+++ b/QUICK_START.md
@@ -1,5 +1,43 @@
 # 🚀 Quick Start Guide - No Coding Experience Required!
 
+## ⚠️ Important Notes
+
+- **Windows Users**: These instructions have been tested on Mac/Linux. Windows users may need to adjust some commands.
+- **Virtual Environment**: We recommend using a virtual environment to avoid package conflicts.
+
+## For Mac Users
+
+### 1. Install Python (if not already installed)
+1. Open Terminal (Applications → Utilities → Terminal)
+2. Install Homebrew: `/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"`
+3. Install Python: `brew install python`
+
+### 2. Download and Setup
+1. Download ZIP from GitHub (green "Code" button)
+2. Extract to your Desktop
+3. Open Terminal and navigate:
+   ```bash
+   cd ~/Desktop/openhands-expense-calculator
+   ```
+
+### 3. Create Virtual Environment (Recommended)
+```bash
+# Create a virtual environment
+python3 -m venv venv
+
+# Activate the virtual environment
+source venv/bin/activate
+```
+
+### 4. Install and Run
+```bash
+# Install required packages
+pip install -r requirements.txt
+
+# Start the expense tracker  
+streamlit run run_app.py
+```
+
 ## For Windows Users
 
 ### 1. Install Python
@@ -18,40 +56,25 @@
 2. Type `cmd` and press Enter
 3. Navigate to your extracted folder:
    ```
-   cd Desktop\openhands-expense-calculator-main
+   cd Desktop\openhands-expense-calculator
    ```
 
-### 4. Install and Run
+### 4. Create Virtual Environment (Recommended)
+```bash
+# Create a virtual environment
+python -m venv venv
+
+# Activate the virtual environment
+venv\Scripts\activate
+```
+
+### 5. Install and Run
 ```bash
 # Install required packages (one-time setup)
 pip install -r requirements.txt
 
 # Start the expense tracker
-python run_app.py
-```
-
-## For Mac Users
-
-### 1. Install Python (if not already installed)
-1. Open Terminal (Applications → Utilities → Terminal)
-2. Install Homebrew: `/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"`
-3. Install Python: `brew install python`
-
-### 2. Download and Setup
-1. Download ZIP from GitHub (green "Code" button)
-2. Extract to your Desktop
-3. Open Terminal and navigate:
-   ```bash
-   cd ~/Desktop/openhands-expense-calculator-main
-   ```
-
-### 3. Install and Run
-```bash
-# Install required packages
-pip3 install -r requirements.txt
-
-# Start the expense tracker  
-python3 run_app.py
+streamlit run run_app.py
 ```
 
 ## What Happens Next?
@@ -83,6 +106,7 @@ python3 run_app.py
 
 - **Can't find Terminal/Command Prompt?** Search for "cmd" on Windows or "Terminal" on Mac
 - **Python not found?** Make sure you checked "Add to PATH" during Python installation
+- **Package conflicts?** Try using a virtual environment (see steps above)
 - **Still stuck?** Check the main README.md file for more detailed troubleshooting
 
 ## 🎉 You're Ready!

--- a/README.md
+++ b/README.md
@@ -4,25 +4,16 @@ A simple, local expense tracking application that helps you manage and visualize
 
 ## 🚀 Quick Start
 
-### What You Need
-- A computer with Python installed (Windows, Mac, or Linux)
-- Your Chase credit card CSV file (downloaded from Chase online banking)
+**New to the application?** Check out our [Quick Start Guide](QUICK_START.md) for step-by-step instructions to get up and running in minutes!
 
-### Step 1: Download the Application
-1. Click the green "Code" button above and select "Download ZIP"
-2. Extract the ZIP file to a folder on your computer
-3. Open a terminal/command prompt and navigate to the folder
+For experienced users, here's the quick setup:
 
-### Step 2: Install Required Software
 ```bash
 # Install the required packages
 pip install -r requirements.txt
-```
 
-### Step 3: Run the Application
-```bash
 # Start the expense tracker
-python run_app.py
+streamlit run run_app.py
 ```
 
 The application will start and automatically open in your web browser at `http://localhost:8501`
@@ -142,10 +133,9 @@ The CSV file should have these columns:
 ## 🛠️ Advanced Usage
 
 ### Running on a Different Port
-Edit `run_app.py` and change the port number:
-```python
-if __name__ == "__main__":
-    main(port=8502)  # Change to your preferred port
+Start the application with a different port:
+```bash
+streamlit run run_app.py --server.port 8502
 ```
 
 ### Accessing from Other Devices


### PR DESCRIPTION
- Standardize on 'pip' instead of 'pip3' throughout documentation
- Remove quick start overlap from README and link to QUICK_START.md
- Add Windows disclaimer for untested instructions
- Fix Mac instructions: correct folder name, add virtual environment setup
- Use 'streamlit run run_app.py' instead of 'python run_app.py'
- Add virtual environment instructions for both Mac and Windows
- Update HANDOFF.md to be consistent with new commands